### PR TITLE
feat: adaption of threads example in ch 9 subsection 15, threads and locks

### DIFF
--- a/threads_example.rb
+++ b/threads_example.rb
@@ -1,0 +1,23 @@
+# example of threads within ruby
+#
+# @param[Integer] num_threads
+#
+def multi_thread(num_threads)
+  puts "fn starting"
+  threads = []
+  i = 0
+  while i < num_threads do
+    puts i
+    threads << Thread.new(i) do | thread_num |
+      puts "thread # #{thread_num} starting work"
+      sleep(1)
+      puts "thread # #{thread_num} finished working"
+    end
+    i += 1
+  end
+
+  threads.each(&:join)
+  puts "fn ending"
+end
+
+multi_thread(10)


### PR DESCRIPTION
note: on line 11, we take ```thread_num``` as a parameter to the block, resulting in a copy of the variable value and not a reference to it.  without this parameter passed explicitly to the block, threads execute and will print the current value of i, as i was passed by reference and not value.